### PR TITLE
Better handling of module version checks

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -55,7 +55,10 @@ function Get-ViewAPIService {
 }
 
 function Get-HVModuleVersion {
-  $hvModules = @( Get-Module -Name "Vmware.VimAutomation.HorizonView" -ErrorAction "SilentlyContinue" );
+  if (-not (Get-Module -Name "Vmware.VimAutomation.HorizonView" -ErrorAction "SilentlyContinue") ) {
+    Import-Module -Name "Vmware.VimAutomation.HorizonView" -ErrorAction Stop
+  }
+  $hvModules = @( Get-Module -Name "Vmware.VimAutomation.HorizonView" -ErrorAction SilentlyContinue);
   return $($hvModules.version | measure -Maximum).Maximum
 }
 


### PR DESCRIPTION
If the module is not loaded, and autoloading does not occur before the `Get-HVModuleVersion` call, the result might be an empty string. This gives a chance to force loading the module and error if it is not available.